### PR TITLE
bump image revision to 9.5.3-r5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/stacksmith-images/ubuntu:14.04-r9
 MAINTAINER Bitnami <containers@bitnami.com>
 
-ENV BITNAMI_IMAGE_VERSION=9.5.3-r4 \
+ENV BITNAMI_IMAGE_VERSION=9.5.3-r5 \
     BITNAMI_APP_NAME=postgresql \
     BITNAMI_APP_USER=postgres
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,13 @@ bats test.sh
 
 # Notable Changes
 
+## 9.5.3-r5
+
+- The `POSTGRES_` prefix on environment variables is now replaced by `POSTGRESQL_`
+- `POSTGRES_USER` parameter has been renamed to `POSTGRESQL_USERNAME`.
+- `POSTGRES_DB` parameter has been renamed to `POSTGRESQL_DATABASE`.
+- `POSTGRES_MODE` parameter has been renamed to `POSTGRESQL_REPLICATION_MODE`.
+
 ## 9.5.3-r0
 
 - All volumes have been merged at `/bitnami/postgresql`. Now you only need to mount a single volume at `/bitnami/postgresql` for persistence.


### PR DESCRIPTION
- The `POSTGRES_` prefix on environment variables is now replaced by
  `POSTGRESQL_`
- `POSTGRES_USER` parameter has been renamed to `POSTGRESQL_USERNAME`.
- `POSTGRES_DB` parameter has been renamed to `POSTGRESQL_DATABASE`.
- `POSTGRES_MODE` parameter has been renamed to
  `POSTGRESQL_REPLICATION_MODE`.