### PR TITLE
replace the bundled common libraries with references to system packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM gcr.io/stacksmith-images/minideb:jessie-r2
+FROM gcr.io/stacksmith-images/minideb:jessie-r4
 MAINTAINER Bitnami <containers@bitnami.com>
 
-ENV BITNAMI_IMAGE_VERSION=9.6.1-r1 \
+ENV BITNAMI_IMAGE_VERSION=9.6.1-r2 \
     BITNAMI_APP_NAME=postgresql \
     BITNAMI_APP_USER=postgres
 
-RUN bitnami-pkg unpack postgresql-9.6.1-0 --checksum 7df40e7408cb28f6b50a1be64d4c57b09c8790ea210e376b4474a9d650c508ef
+
+# System packages required
+RUN install_packages --no-install-recommends libc6 libssl1.0.0 zlib1g libxml2 liblzma5 libedit2 libbsd0 libtinfo5 libxslt1.1
+
+# Install postgresql
+RUN bitnami-pkg unpack postgresql-9.6.1-1 --checksum af594552c2e9644bc51539414ed297701d347be450cd2b9c14a1082ef8f56e69
 ENV PATH=/opt/bitnami/$BITNAMI_APP_NAME/sbin:/opt/bitnami/$BITNAMI_APP_NAME/bin:$PATH
 
-COPY rootfs/ /
+COPY rootfs /
 
 VOLUME ["/bitnami/$BITNAMI_APP_NAME"]
 


### PR DESCRIPTION
Additional changes:
 - Updates the base image revision to `minideb-buildpack:jessie-r4`