### PR TITLE
Add locale-gen en_US.UTF-8 for debian-based images.

### DIFF
--- a/10/debian-9/Dockerfile
+++ b/10/debian-9/Dockerfile
@@ -6,6 +6,8 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
 
 # Install required system packages and dependencies
 RUN install_packages libbsd0 libc6 libedit2 libgcc1 libicu57 liblzma5 libncurses5 libnss-wrapper libssl1.1 libstdc++6 libtinfo5 libxml2 libxslt1.1 zlib1g
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales
 RUN bitnami-pkg unpack postgresql-10.6.0-0 --checksum f0bb8935dfbf9e486d0074f8e1b9ff9ebb38cf1bd95e4eb3d5fd017822bc1cde
 RUN mkdir /docker-entrypoint-initdb.d /opt/bitnami/postgresql/conf/
 RUN chmod -R g+rwX /opt/bitnami/postgresql/conf/

--- a/11/debian-9/Dockerfile
+++ b/11/debian-9/Dockerfile
@@ -6,6 +6,8 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
 
 # Install required system packages and dependencies
 RUN install_packages libbsd0 libc6 libedit2 libgcc1 libicu57 liblzma5 libncurses5 libnss-wrapper libssl1.1 libstdc++6 libtinfo5 libxml2 libxslt1.1 zlib1g
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales
 RUN bitnami-pkg unpack postgresql-11.1.0-0 --checksum 35dd63db8c527ea40f05e244fefedb8eb8e146b122328b8d767f9fa310a97700
 RUN mkdir /docker-entrypoint-initdb.d /opt/bitnami/postgresql/conf/
 RUN chmod -R g+rwX /opt/bitnami/postgresql/conf/

--- a/9.6/debian-9/Dockerfile
+++ b/9.6/debian-9/Dockerfile
@@ -6,6 +6,8 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
 
 # Install required system packages and dependencies
 RUN install_packages libbsd0 libc6 libedit2 libgcc1 libicu57 liblzma5 libncurses5 libnss-wrapper libssl1.1 libstdc++6 libtinfo5 libxml2 libxslt1.1 zlib1g
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales
 RUN bitnami-pkg unpack postgresql-9.6.11-0 --checksum f727a1dd30fcdfada9e3b53558aedd15e9c5d77434ea653a451c9357048ad975
 RUN mkdir /docker-entrypoint-initdb.d /opt/bitnami/postgresql/conf/
 RUN chmod -R g+rwX /opt/bitnami/postgresql/conf/


### PR DESCRIPTION
Related to https://github.com/helm/charts/issues/9232 for backward compatibility

Migrating existing postgresql chart to >=2.0.0 results (after manual process) in existing database unusable because of missing en_US locale:
```
The database was initialized with LC_COLLATE "en_US.utf8",  which is not recognized by setlocale().
```