### PR TITLE
Sort init scripts alphabetically

### DIFF
--- a/10/debian-9/rootfs/run.sh
+++ b/10/debian-9/rootfs/run.sh
@@ -61,7 +61,7 @@ if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.
         exit 1
     fi
     tmp_file=/tmp/filelist
-    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" > $tmp_file
+    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort > $tmp_file
     while read -r f; do
         case "$f" in
             *.sh)

--- a/10/ol-7/rootfs/run.sh
+++ b/10/ol-7/rootfs/run.sh
@@ -61,7 +61,7 @@ if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.
         exit 1
     fi
     tmp_file=/tmp/filelist
-    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" > $tmp_file
+    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort > $tmp_file
     while read -r f; do
         case "$f" in
             *.sh)

--- a/11/debian-9/rootfs/run.sh
+++ b/11/debian-9/rootfs/run.sh
@@ -61,7 +61,7 @@ if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.
         exit 1
     fi
     tmp_file=/tmp/filelist
-    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" > $tmp_file
+    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort > $tmp_file
     while read -r f; do
         case "$f" in
             *.sh)

--- a/11/ol-7/rootfs/run.sh
+++ b/11/ol-7/rootfs/run.sh
@@ -61,7 +61,7 @@ if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.
         exit 1
     fi
     tmp_file=/tmp/filelist
-    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" > $tmp_file
+    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort > $tmp_file
     while read -r f; do
         case "$f" in
             *.sh)

--- a/9.6/debian-9/rootfs/run.sh
+++ b/9.6/debian-9/rootfs/run.sh
@@ -61,7 +61,7 @@ if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.
         exit 1
     fi
     tmp_file=/tmp/filelist
-    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" > $tmp_file
+    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort > $tmp_file
     while read -r f; do
         case "$f" in
             *.sh)

--- a/9.6/ol-7/rootfs/run.sh
+++ b/9.6/ol-7/rootfs/run.sh
@@ -61,7 +61,7 @@ if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.
         exit 1
     fi
     tmp_file=/tmp/filelist
-    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" > $tmp_file
+    find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort > $tmp_file
     while read -r f; do
         case "$f" in
             *.sh)


### PR DESCRIPTION
**Description of the change**

When specifying multiple init scripts they are run in an undefined order because the `find` command does not order the results in any way. This PR adds a `sort` after `find` to sort the init scripts alphabetically, so they are run that it that order.

**Benefits**

You can have your init scripts run in a specific order.

**Possible drawbacks**

If somebody was relying on the current pseudo random order of their init scripts, this might break that order.
