### PR TITLE
Fix environment variable conversion not being escaped

### DIFF
--- a/10/debian-9/rootfs/app-entrypoint.sh
+++ b/10/debian-9/rootfs/app-entrypoint.sh
@@ -38,7 +38,7 @@ if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/run.sh" ]]; then
 
   declareEnvironmentVariableAlias() {
       if env | grep -q "$2"; then
-          export $1=${!2}
+          export $1="${!2}"
       fi
   }
 

--- a/10/ol-7/rootfs/app-entrypoint.sh
+++ b/10/ol-7/rootfs/app-entrypoint.sh
@@ -38,7 +38,7 @@ if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/run.sh" ]]; then
 
   declareEnvironmentVariableAlias() {
       if env | grep -q "$2"; then
-          export $1=${!2}
+          export $1="${!2}"
       fi
   }
 

--- a/11/debian-9/rootfs/app-entrypoint.sh
+++ b/11/debian-9/rootfs/app-entrypoint.sh
@@ -38,7 +38,7 @@ if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/run.sh" ]]; then
 
   declareEnvironmentVariableAlias() {
       if env | grep -q "$2"; then
-          export $1=${!2}
+          export $1="${!2}"
       fi
   }
 

--- a/11/ol-7/rootfs/app-entrypoint.sh
+++ b/11/ol-7/rootfs/app-entrypoint.sh
@@ -38,7 +38,7 @@ if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/run.sh" ]]; then
 
   declareEnvironmentVariableAlias() {
       if env | grep -q "$2"; then
-          export $1=${!2}
+          export $1="${!2}"
       fi
   }
 

--- a/9.6/debian-9/rootfs/app-entrypoint.sh
+++ b/9.6/debian-9/rootfs/app-entrypoint.sh
@@ -38,7 +38,7 @@ if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/run.sh" ]]; then
 
   declareEnvironmentVariableAlias() {
       if env | grep -q "$2"; then
-          export $1=${!2}
+          export $1="${!2}"
       fi
   }
 

--- a/9.6/ol-7/rootfs/app-entrypoint.sh
+++ b/9.6/ol-7/rootfs/app-entrypoint.sh
@@ -38,7 +38,7 @@ if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/run.sh" ]]; then
 
   declareEnvironmentVariableAlias() {
       if env | grep -q "$2"; then
-          export $1=${!2}
+          export $1="${!2}"
       fi
   }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Properly escape the converted environment variables

**Benefits**

Environment variables containing whitespaces will now work again

**Possible drawbacks**

None that I know of

**Applicable issues**

#123 

**Additional information**

-