### PR TITLE
Password length is limited to 63 characters instead of 32

### DIFF
--- a/10/debian-9/rootfs/libpostgresql.sh
+++ b/10/debian-9/rootfs/libpostgresql.sh
@@ -154,8 +154,8 @@ postgresql_validate() {
             empty_password_error "POSTGRESQL_PASSWORD"
             exit 1
         fi
-        if (( ${#POSTGRESQL_PASSWORD} > 32 )); then
-            error "The password cannot be longer than 32 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
+        if (( ${#POSTGRESQL_PASSWORD} > 63 )); then
+            error "The password cannot be longer than 63 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
             exit 1
         fi
         if [[ -n "$POSTGRESQL_USERNAME" ]] && [[ -z "$POSTGRESQL_PASSWORD" ]]; then

--- a/10/ol-7/rootfs/libpostgresql.sh
+++ b/10/ol-7/rootfs/libpostgresql.sh
@@ -154,8 +154,8 @@ postgresql_validate() {
             empty_password_error "POSTGRESQL_PASSWORD"
             exit 1
         fi
-        if (( ${#POSTGRESQL_PASSWORD} > 32 )); then
-            error "The password cannot be longer than 32 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
+        if (( ${#POSTGRESQL_PASSWORD} > 63 )); then
+            error "The password cannot be longer than 63 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
             exit 1
         fi
         if [[ -n "$POSTGRESQL_USERNAME" ]] && [[ -z "$POSTGRESQL_PASSWORD" ]]; then

--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -154,8 +154,8 @@ postgresql_validate() {
             empty_password_error "POSTGRESQL_PASSWORD"
             exit 1
         fi
-        if (( ${#POSTGRESQL_PASSWORD} > 32 )); then
-            error "The password cannot be longer than 32 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
+        if (( ${#POSTGRESQL_PASSWORD} > 63 )); then
+            error "The password cannot be longer than 63 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
             exit 1
         fi
         if [[ -n "$POSTGRESQL_USERNAME" ]] && [[ -z "$POSTGRESQL_PASSWORD" ]]; then

--- a/11/ol-7/rootfs/libpostgresql.sh
+++ b/11/ol-7/rootfs/libpostgresql.sh
@@ -154,8 +154,8 @@ postgresql_validate() {
             empty_password_error "POSTGRESQL_PASSWORD"
             exit 1
         fi
-        if (( ${#POSTGRESQL_PASSWORD} > 32 )); then
-            error "The password cannot be longer than 32 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
+        if (( ${#POSTGRESQL_PASSWORD} > 63 )); then
+            error "The password cannot be longer than 63 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
             exit 1
         fi
         if [[ -n "$POSTGRESQL_USERNAME" ]] && [[ -z "$POSTGRESQL_PASSWORD" ]]; then

--- a/9.6/debian-9/rootfs/libpostgresql.sh
+++ b/9.6/debian-9/rootfs/libpostgresql.sh
@@ -154,8 +154,8 @@ postgresql_validate() {
             empty_password_error "POSTGRESQL_PASSWORD"
             exit 1
         fi
-        if (( ${#POSTGRESQL_PASSWORD} > 32 )); then
-            error "The password cannot be longer than 32 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
+        if (( ${#POSTGRESQL_PASSWORD} > 63 )); then
+            error "The password cannot be longer than 63 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
             exit 1
         fi
         if [[ -n "$POSTGRESQL_USERNAME" ]] && [[ -z "$POSTGRESQL_PASSWORD" ]]; then

--- a/9.6/ol-7/rootfs/libpostgresql.sh
+++ b/9.6/ol-7/rootfs/libpostgresql.sh
@@ -154,8 +154,8 @@ postgresql_validate() {
             empty_password_error "POSTGRESQL_PASSWORD"
             exit 1
         fi
-        if (( ${#POSTGRESQL_PASSWORD} > 32 )); then
-            error "The password cannot be longer than 32 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
+        if (( ${#POSTGRESQL_PASSWORD} > 63 )); then
+            error "The password cannot be longer than 63 characters. Set the environment variable POSTGRESQL_PASSWORD with a shorter value"
             exit 1
         fi
         if [[ -n "$POSTGRESQL_USERNAME" ]] && [[ -z "$POSTGRESQL_PASSWORD" ]]; then


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR updates the passwords' characters limit to 63.

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/bitnami-docker-postgresql/issues/129
