### PR TITLE
Copy all files when moving configuration files from mounted dir to conf dir

### DIFF
--- a/10/debian-9/rootfs/libpostgresql.sh
+++ b/10/debian-9/rootfs/libpostgresql.sh
@@ -432,7 +432,7 @@ postgresql_initialize() {
     # User injected custom configuration
     if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* > /dev/null;then
         debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/* "$POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
     fi
     local create_conf_file=yes
     local create_pghba_file=yes

--- a/10/ol-7/rootfs/libpostgresql.sh
+++ b/10/ol-7/rootfs/libpostgresql.sh
@@ -432,7 +432,7 @@ postgresql_initialize() {
     # User injected custom configuration
     if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* > /dev/null;then
         debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/* "$POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
     fi
     local create_conf_file=yes
     local create_pghba_file=yes

--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -432,7 +432,7 @@ postgresql_initialize() {
     # User injected custom configuration
     if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* > /dev/null;then
         debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/* "$POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
     fi
     local create_conf_file=yes
     local create_pghba_file=yes

--- a/11/ol-7/rootfs/libpostgresql.sh
+++ b/11/ol-7/rootfs/libpostgresql.sh
@@ -432,7 +432,7 @@ postgresql_initialize() {
     # User injected custom configuration
     if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* > /dev/null;then
         debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/* "$POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
     fi
     local create_conf_file=yes
     local create_pghba_file=yes

--- a/9.6/debian-9/rootfs/libpostgresql.sh
+++ b/9.6/debian-9/rootfs/libpostgresql.sh
@@ -432,7 +432,7 @@ postgresql_initialize() {
     # User injected custom configuration
     if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* > /dev/null;then
         debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/* "$POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
     fi
     local create_conf_file=yes
     local create_pghba_file=yes

--- a/9.6/ol-7/rootfs/libpostgresql.sh
+++ b/9.6/ol-7/rootfs/libpostgresql.sh
@@ -432,7 +432,7 @@ postgresql_initialize() {
     # User injected custom configuration
     if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* > /dev/null;then
         debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/* "$POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
     fi
     local create_conf_file=yes
     local create_pghba_file=yes


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

As it is designed right now, when a user wants to use custom config file they should mount the files at _/bitnami/postgresql/conf_ and during initialization, they are being copied to _/opt/bitnami/postgresql/conf_.

Kubernetes contig maps are relative symlinks to other files in the same directory, so we should copy all the files so that the final config file is able to follow the symlink.

**Benefits**

PostgreSQL helm chart can use config maps to load the configuration.

**Possible drawbacks**



**Applicable issues**

https://github.com/helm/charts/issues/13650

**Additional information**

