### PR TITLE
Ensure it doesn't recognize an empty directory as 'persisted data'

### DIFF
--- a/10/centos-7/rootfs/libpostgresql.sh
+++ b/10/centos-7/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then

--- a/10/debian-9/rootfs/libpostgresql.sh
+++ b/10/debian-9/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then

--- a/10/ol-7/rootfs/libpostgresql.sh
+++ b/10/ol-7/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then

--- a/11/centos-7/rootfs/libpostgresql.sh
+++ b/11/centos-7/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then

--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then

--- a/11/ol-7/rootfs/libpostgresql.sh
+++ b/11/ol-7/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then

--- a/9.6/centos-7/rootfs/libpostgresql.sh
+++ b/9.6/centos-7/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then

--- a/9.6/debian-9/rootfs/libpostgresql.sh
+++ b/9.6/debian-9/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then

--- a/9.6/ol-7/rootfs/libpostgresql.sh
+++ b/9.6/ol-7/rootfs/libpostgresql.sh
@@ -488,7 +488,7 @@ postgresql_initialize() {
     is_boolean_yes "$create_conf_file" && postgresql_create_config
     is_boolean_yes "$create_pghba_file" && postgresql_create_pghba && postgresql_allow_local_connection
 
-    if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    if ! is_dir_empty "$POSTGRESQL_DATA_DIR"; then
         info "Deploying PostgreSQL with persisted data..."
         local -r postmaster_path="$POSTGRESQL_DATA_DIR"/postmaster.pid
         if [[ -f "$postmaster_path" ]]; then


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

### Description of the change

This PR ensures an empty "data directory" is not considered as persisted that needs to be used.
