### PR TITLE
Fix: use `printenv` instead of `env | grep -q`

### DIFF
--- a/10/centos-7/rootfs/libpostgresql.sh
+++ b/10/centos-7/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF

--- a/10/debian-9/rootfs/libpostgresql.sh
+++ b/10/debian-9/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF

--- a/10/ol-7/rootfs/libpostgresql.sh
+++ b/10/ol-7/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF

--- a/11/centos-7/rootfs/libpostgresql.sh
+++ b/11/centos-7/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF

--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF

--- a/11/ol-7/rootfs/libpostgresql.sh
+++ b/11/ol-7/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF

--- a/9.6/centos-7/rootfs/libpostgresql.sh
+++ b/9.6/centos-7/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF

--- a/9.6/debian-9/rootfs/libpostgresql.sh
+++ b/9.6/debian-9/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF

--- a/9.6/ol-7/rootfs/libpostgresql.sh
+++ b/9.6/ol-7/rootfs/libpostgresql.sh
@@ -47,7 +47,7 @@ postgresql_env() {
       local -r alias="${1:?missing environment variable alias}"
       local -r original="${2:?missing original environment variable}"
 
-      if env | grep -q "${original}"; then
+      if printenv "${original}" > /dev/null; then
           cat << EOF
 export $alias="${!original}"
 EOF


### PR DESCRIPTION
 `grep -q` might lead to exit status 141 which with `set -o pipefail` leads to the `declare_env_alias` function not working properly. 
As a fix, with my poor bash knowledge, I can suggest using `printenv` instead.

Related issue: https://github.com/bitnami/bitnami-docker-postgresql/issues/152

**Additional information**

I'm not sure if it will work for all OSs, I only checked it for `11.3.0-debian-9-r38`.