### PR TITLE
Add specific environment variable postgres user password

### DIFF
--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -60,10 +60,11 @@ EOF
     [[ -z "${POSTGRESQL_DATA_DIR:-}" ]] && declare_env_alias POSTGRESQL_DATA_DIR PGDATA
 
     local -r suffixes=(
-      "PASSWORD" "INITDB_WAL_DIR" "INITDB_ARGS" "CLUSTER_APP_NAME"
+      "PASSWORD" "POSTGRES_PASSWORD" "INITDB_WAL_DIR" "INITDB_ARGS" "CLUSTER_APP_NAME"
       "MASTER_HOST" "MASTER_PORT_NUMBER" "NUM_SYNCHRONOUS_REPLICAS"
       "PORT_NUMBER" "REPLICATION_MODE" "REPLICATION_PASSWORD" "REPLICATION_USER" "FSYNC"
-      "SYNCHRONOUS_COMMIT_MODE" "PASSWORD_FILE" "REPLICATION_PASSWORD_FILE" "INIT_MAX_TIMEOUT"
+      "SYNCHRONOUS_COMMIT_MODE" "PASSWORD_FILE" "POSTGRES_PASSWORD_FILE"
+      "REPLICATION_PASSWORD_FILE" "INIT_MAX_TIMEOUT"
     )
     for s in "${suffixes[@]}"; do
       declare_env_alias "POSTGRESQL_${s}" "POSTGRES_${s}"
@@ -522,7 +523,7 @@ postgresql_initialize() {
             if [[ "$POSTGRESQL_USERNAME" = "postgres" ]]; then
                 postgresql_alter_postgres_user "$POSTGRESQL_PASSWORD"
             else
-                if [[ ! -z "$POSTGRESQL_POSTGRES_PASSWORD" ]]; then
+                if [[ -n "$POSTGRESQL_POSTGRES_PASSWORD" ]]; then
                     postgresql_alter_postgres_user "$POSTGRESQL_POSTGRES_PASSWORD"
                 fi
                 postgresql_create_admin_user

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ services:
 **Note!**
 The `postgres` user is a superuser and has full administrative access to the PostgreSQL database.
 
+Refer to [Creating a database user on first run](#creating-a-database-user-on-first-run) if you want to set an unprivileged user and a password for the `postgres` user.
+
 ## Creating a database on first run
 
 By passing the `POSTGRESQL_DATABASE` environment variable when running the image for the first time, a database will be created. This is useful if your application requires that a database already exists, saving you from having to manually create the database using the PostgreSQL client.
@@ -240,7 +242,7 @@ services:
 ```
 
 **Note!**
-When `POSTGRESQL_USERNAME` is specified, the `postgres` user is not assigned a password and as a result you cannot login remotely to the PostgreSQL server as the `postgres` user.
+When `POSTGRESQL_USERNAME` is specified, the `postgres` user is not assigned a password and as a result you cannot login remotely to the PostgreSQL server as the `postgres` user. If you still want to have access with the user `postgres`, please set the `POSTGRESQL_POSTGRES_PASSWORD` environment variable (or the content of the file specified in `POSTGRESQL_POSTGRES_PASSWORD_FILE`).
 
 ## Setting up a streaming replication
 
@@ -550,6 +552,8 @@ The Bitnami PostgreSQL container allows two different sets of environment variab
 | POSTGRESQL_DATABASE                  | POSTGRES_DB                        |
 | POSTGRESQL_PASSWORD                  | POSTGRES_PASSWORD                  |
 | POSTGRESQL_PASSWORD_FILE             | POSTGRES_PASSWORD_FILE             |
+| POSTGRESQL_POSTGRES_PASSWORD         | POSTGRES_POSTGRES_PASSWORD         |
+| POSTGRESQL_POSTGRES_PASSWORD_FILE    | POSTGRES_POSTGRES_PASSWORD_FILE    |
 | POSTGRESQL_PORT_NUMBER               | POSTGRES_PORT_NUMBER               |
 | POSTGRESQL_INITDB_ARGS               | POSTGRES_INITDB_ARGS               |
 | POSTGRESQL_INITDB_WALDIR             | POSTGRES_INITDB_WALDIR             |


### PR DESCRIPTION
This PR adds an environment variable through which users can set a password for `postgres` user. But it only adds it for version 11 of Postgres on Ubuntu. If it seems ok to you I can go on and add the same environment variable for other operating systems and Postgres versions as well. 