### PR TITLE
Add POSTGRESQL_PREINITSCRIPTS_DIR env to run scripts before postgresql start

### DIFF
--- a/10/centos-7/Dockerfile
+++ b/10/centos-7/Dockerfile
@@ -22,7 +22,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib64/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/10/centos-7/rootfs/libpostgresql.sh
+++ b/10/centos-7/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/10/centos-7/rootfs/libpostgresql.sh
+++ b/10/centos-7/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/10/centos-7/rootfs/libpostgresql.sh
+++ b/10/centos-7/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/10/centos-7/rootfs/setup.sh
+++ b/10/centos-7/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/10/centos-7/rootfs/setup.sh
+++ b/10/centos-7/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/10/debian-9/Dockerfile
+++ b/10/debian-9/Dockerfile
@@ -23,7 +23,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/10/debian-9/rootfs/libpostgresql.sh
+++ b/10/debian-9/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/10/debian-9/rootfs/libpostgresql.sh
+++ b/10/debian-9/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/10/debian-9/rootfs/libpostgresql.sh
+++ b/10/debian-9/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/10/debian-9/rootfs/setup.sh
+++ b/10/debian-9/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/10/debian-9/rootfs/setup.sh
+++ b/10/debian-9/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/10/ol-7/Dockerfile
+++ b/10/ol-7/Dockerfile
@@ -22,7 +22,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib64/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/10/ol-7/rootfs/libpostgresql.sh
+++ b/10/ol-7/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/10/ol-7/rootfs/libpostgresql.sh
+++ b/10/ol-7/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/10/ol-7/rootfs/libpostgresql.sh
+++ b/10/ol-7/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/10/ol-7/rootfs/setup.sh
+++ b/10/ol-7/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/10/ol-7/rootfs/setup.sh
+++ b/10/ol-7/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/11/centos-7/Dockerfile
+++ b/11/centos-7/Dockerfile
@@ -22,7 +22,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib64/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/11/centos-7/rootfs/libpostgresql.sh
+++ b/11/centos-7/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/11/centos-7/rootfs/libpostgresql.sh
+++ b/11/centos-7/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/11/centos-7/rootfs/libpostgresql.sh
+++ b/11/centos-7/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/11/centos-7/rootfs/setup.sh
+++ b/11/centos-7/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/11/centos-7/rootfs/setup.sh
+++ b/11/centos-7/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/11/debian-9/Dockerfile
+++ b/11/debian-9/Dockerfile
@@ -23,7 +23,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/11/debian-9/rootfs/setup.sh
+++ b/11/debian-9/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/11/debian-9/rootfs/setup.sh
+++ b/11/debian-9/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/11/ol-7/Dockerfile
+++ b/11/ol-7/Dockerfile
@@ -22,7 +22,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib64/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/11/ol-7/rootfs/libpostgresql.sh
+++ b/11/ol-7/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/11/ol-7/rootfs/libpostgresql.sh
+++ b/11/ol-7/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/11/ol-7/rootfs/libpostgresql.sh
+++ b/11/ol-7/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/11/ol-7/rootfs/setup.sh
+++ b/11/ol-7/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/11/ol-7/rootfs/setup.sh
+++ b/11/ol-7/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/9.6/centos-7/Dockerfile
+++ b/9.6/centos-7/Dockerfile
@@ -22,7 +22,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib64/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/9.6/centos-7/rootfs/libpostgresql.sh
+++ b/9.6/centos-7/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/9.6/centos-7/rootfs/libpostgresql.sh
+++ b/9.6/centos-7/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/9.6/centos-7/rootfs/libpostgresql.sh
+++ b/9.6/centos-7/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/9.6/centos-7/rootfs/setup.sh
+++ b/9.6/centos-7/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/9.6/centos-7/rootfs/setup.sh
+++ b/9.6/centos-7/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/9.6/debian-9/Dockerfile
+++ b/9.6/debian-9/Dockerfile
@@ -23,7 +23,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/9.6/debian-9/rootfs/libpostgresql.sh
+++ b/9.6/debian-9/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/9.6/debian-9/rootfs/libpostgresql.sh
+++ b/9.6/debian-9/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/9.6/debian-9/rootfs/libpostgresql.sh
+++ b/9.6/debian-9/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/9.6/debian-9/rootfs/setup.sh
+++ b/9.6/debian-9/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/9.6/debian-9/rootfs/setup.sh
+++ b/9.6/debian-9/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/9.6/ol-7/Dockerfile
+++ b/9.6/ol-7/Dockerfile
@@ -22,7 +22,7 @@ ENV BITNAMI_APP_NAME="postgresql" \
     NSS_WRAPPER_LIB="/usr/lib64/libnss_wrapper.so" \
     PATH="/opt/bitnami/postgresql/bin:$PATH"
 
-VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d" ]
+VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
 EXPOSE 5432
 

--- a/9.6/ol-7/rootfs/libpostgresql.sh
+++ b/9.6/ol-7/rootfs/libpostgresql.sh
@@ -98,6 +98,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
+export POSTGRESQL_PREINITSCRIPTS_DIR=/docker-entrypoint-preinitdb.d
 export PATH="$POSTGRESQL_BIN_DIR:$PATH"
 
 # Users

--- a/9.6/ol-7/rootfs/libpostgresql.sh
+++ b/9.6/ol-7/rootfs/libpostgresql.sh
@@ -560,7 +560,11 @@ postgresql_custom_pre_init_scripts() {
     if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
         info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
         find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
-            debug "Executing $f"; "$f"
+            if [[ -x "$f" ]]; then
+                debug "Executing $f"; "$f"
+            else
+                debug "Sourcing $f"; . "$f"
+            fi
         done
     fi
 }

--- a/9.6/ol-7/rootfs/libpostgresql.sh
+++ b/9.6/ol-7/rootfs/libpostgresql.sh
@@ -547,6 +547,25 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom pre-initialization scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_pre_init_scripts() {
+    info "Loading custom pre-init scripts..."
+    if [[ -n $(find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+        info "Loading user's custom files from $POSTGRESQL_PREINITSCRIPTS_DIR ...";
+        find "$POSTGRESQL_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            debug "Executing $f"; "$f"
+        done
+    fi
+}
+
+########################
 # Run custom initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/9.6/ol-7/rootfs/setup.sh
+++ b/9.6/ol-7/rootfs/setup.sh
@@ -30,6 +30,7 @@ am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GR
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
+postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/9.6/ol-7/rootfs/setup.sh
+++ b/9.6/ol-7/rootfs/setup.sh
@@ -27,10 +27,11 @@ postgresql_validate
 trap "postgresql_stop" EXIT
 # Ensure 'daemon' user exists when running as 'root'
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" "$POSTGRESQL_DAEMON_GROUP"
+# Allow running custom pre-initialization scripts
+postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized
 postgresql_initialize
 # Allow running custom initialization scripts
-postgresql_custom_pre_init_scripts
 postgresql_custom_init_scripts
 
 # Allow remote connections once the initialization is finished

--- a/README.md
+++ b/README.md
@@ -171,9 +171,15 @@ $ docker-compose up -d
 
 # Configuration
 
+## On container start
+
+When the container is executed, it will execute the files with extension `.sh` located at `/docker-entrypoint-preinitdb.d` before initializing or starting postgresql.
+
+In order to have your custom files inside the docker image you can mount them as a volume.
+
 ## Initializing a new instance
 
-When the container is executed for the first time, it will execute the files with extensions `.sh`, `.sql` and `.sql.gz` located at `/docker-entrypoint-initdb.d`.
+When the container is executed for the first time, it will execute the files with extensions `.sh`, `.sql` and `.sql.gz` located at `/docker-entrypoint-initdb.d` after starting postgresql.
 
 In order to have your custom files inside the docker image you can mount them as a volume.
 


### PR DESCRIPTION

**Description of the change**

Adds env that points to a directory where scripts can be placed that will get run _before_ postgresql is started. 

**Benefits**

The reason I've created this is because for certain OpenShift storage provider for PV's, a recursive chown and chmod is run by kubernetes everytime the pod is recreated. This recursive chown breaks postgresql because postgresql checks and sees group permissions of the data directory to be too open (the recursive chmod set group +rw). This env allows to run a script before postgresql attempts to start, where a chmod can be run to set correct permissions.

**Possible drawbacks**

More complex than simply adding "chmod g-rw $DATA_DIR" somewhere in startup, but I took this route because it may have other uses 

**Applicable issues**

**Additional information**

This is related to RedHat case https://access.redhat.com/solutions/3777101 and others where certain storage types get recursive chown / chmod as explained. This is still happening on my OpenShift 3.11 cluster using vshpere cloud provider backed PVs.
