### PR TITLE
Enable custom init scripts only in master mode

### DIFF
--- a/10/centos-7/rootfs/libpostgresql.sh
+++ b/10/centos-7/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/10/debian-9/rootfs/libpostgresql.sh
+++ b/10/debian-9/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/10/ol-7/rootfs/libpostgresql.sh
+++ b/10/ol-7/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/11/centos-7/rootfs/libpostgresql.sh
+++ b/11/centos-7/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/11/debian-9/rootfs/libpostgresql.sh
+++ b/11/debian-9/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/11/ol-7/rootfs/libpostgresql.sh
+++ b/11/ol-7/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/12/centos-7/rootfs/libpostgresql.sh
+++ b/12/centos-7/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/12/debian-9/rootfs/libpostgresql.sh
+++ b/12/debian-9/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/12/ol-7/rootfs/libpostgresql.sh
+++ b/12/ol-7/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/9.6/centos-7/rootfs/libpostgresql.sh
+++ b/9.6/centos-7/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/9.6/debian-9/rootfs/libpostgresql.sh
+++ b/9.6/debian-9/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do

--- a/9.6/ol-7/rootfs/libpostgresql.sh
+++ b/9.6/ol-7/rootfs/libpostgresql.sh
@@ -718,7 +718,7 @@ postgresql_custom_pre_init_scripts() {
 #########################
 postgresql_custom_init_scripts() {
     postgresql_info "Loading custom scripts..."
-    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] ; then
+    if [[ -n $(find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$POSTGRESQL_VOLUME_DIR/.user_scripts_initialized" ]] && [[ "$POSTGRESQL_REPLICATION_MODE" = "master" ]] ; then
         postgresql_info "Loading user's custom files from $POSTGRESQL_INITSCRIPTS_DIR ...";
         postgresql_start_bg
         find "$POSTGRESQL_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do


### PR DESCRIPTION
Since 3rd party may custom image from bitnami, it's better to run scripts only on master.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
All libpostgresql.sh are modified to check the POSTGRESQL_REPLICATION_MODE in postgresql_custom_init_scripts

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Only run scripts on master.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
Not yet found.

<!-- Describe any known limitations with your change -->

**Applicable issues**
bitnami based timescale/timescaledb can't start slave pod
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**
Please check the docker file at
https://github.com/timescale/timescaledb-docker/tree/master/bitnami
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
