### PR TITLE
PGHBA conf updated to allow pods running with ipv6 to support replication

### DIFF
--- a/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -315,6 +315,7 @@ postgresql_add_replication_to_pghba() {
     fi
     cat << EOF >> "$POSTGRESQL_PGHBA_FILE"
 host      replication     all             0.0.0.0/0               ${replication_auth}
+host      replication     all             ::/0                    ${replication_auth}
 EOF
 }
 

--- a/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -315,6 +315,7 @@ postgresql_add_replication_to_pghba() {
     fi
     cat << EOF >> "$POSTGRESQL_PGHBA_FILE"
 host      replication     all             0.0.0.0/0               ${replication_auth}
+host      replication     all             ::/0                    ${replication_auth}
 EOF
 }
 

--- a/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -315,6 +315,7 @@ postgresql_add_replication_to_pghba() {
     fi
     cat << EOF >> "$POSTGRESQL_PGHBA_FILE"
 host      replication     all             0.0.0.0/0               ${replication_auth}
+host      replication     all             ::/0                    ${replication_auth}
 EOF
 }
 

--- a/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -315,6 +315,7 @@ postgresql_add_replication_to_pghba() {
     fi
     cat << EOF >> "$POSTGRESQL_PGHBA_FILE"
 host      replication     all             0.0.0.0/0               ${replication_auth}
+host      replication     all             ::/0                    ${replication_auth}
 EOF
 }
 


### PR DESCRIPTION
**Description of the change**

Used to get this error line "no pg_hba.conf entry for replication connection from host "{{ipv6 address}}", user "repl_user", SSL off" when I am trying to use replication. The change resolved the issue #228.

**Benefits**

Replication will be supoorted for ipv6 based pods also.

**Additional information**

Made the change, built the image with the change, tested and verified