### PR TITLE
Change postgresql_tls_auth_configuration to be consistent on startup

### DIFF
--- a/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -636,10 +636,9 @@ postgresql_initialize() {
             is_boolean_yes "$create_conf_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && postgresql_configure_tls
             postgresql_configure_recovery
         fi
-        # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
-        is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     fi
-
+    # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
+    is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     is_boolean_yes "$create_conf_file" && [[ -n "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES" ]] && postgresql_set_property "shared_preload_libraries" "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES"
     is_boolean_yes "$create_conf_file" && postgresql_configure_logging
     is_boolean_yes "$create_conf_file" && postgresql_configure_connections

--- a/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -636,10 +636,9 @@ postgresql_initialize() {
             is_boolean_yes "$create_conf_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && postgresql_configure_tls
             postgresql_configure_recovery
         fi
-        # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
-        is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     fi
-
+    # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
+    is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     is_boolean_yes "$create_conf_file" && [[ -n "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES" ]] && postgresql_set_property "shared_preload_libraries" "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES"
     is_boolean_yes "$create_conf_file" && postgresql_configure_logging
     is_boolean_yes "$create_conf_file" && postgresql_configure_connections

--- a/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -636,10 +636,9 @@ postgresql_initialize() {
             is_boolean_yes "$create_conf_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && postgresql_configure_tls
             postgresql_configure_recovery
         fi
-        # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
-        is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     fi
-
+    # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
+    is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     is_boolean_yes "$create_conf_file" && [[ -n "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES" ]] && postgresql_set_property "shared_preload_libraries" "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES"
     is_boolean_yes "$create_conf_file" && postgresql_configure_logging
     is_boolean_yes "$create_conf_file" && postgresql_configure_connections

--- a/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -636,10 +636,9 @@ postgresql_initialize() {
             is_boolean_yes "$create_conf_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && postgresql_configure_tls
             postgresql_configure_recovery
         fi
-        # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
-        is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     fi
-
+    # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
+    is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     is_boolean_yes "$create_conf_file" && [[ -n "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES" ]] && postgresql_set_property "shared_preload_libraries" "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES"
     is_boolean_yes "$create_conf_file" && postgresql_configure_logging
     is_boolean_yes "$create_conf_file" && postgresql_configure_connections

--- a/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -636,10 +636,9 @@ postgresql_initialize() {
             is_boolean_yes "$create_conf_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && postgresql_configure_tls
             postgresql_configure_recovery
         fi
-        # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
-        is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     fi
-
+    # TLS Modifications on pghba need to be performed after properly configuring postgresql.conf file
+    is_boolean_yes "$create_pghba_file" && is_boolean_yes "$POSTGRESQL_ENABLE_TLS" && [[ -n $POSTGRESQL_TLS_CA_FILE ]] && postgresql_tls_auth_configuration
     is_boolean_yes "$create_conf_file" && [[ -n "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES" ]] && postgresql_set_property "shared_preload_libraries" "$POSTGRESQL_SHARED_PRELOAD_LIBRARIES"
     is_boolean_yes "$create_conf_file" && postgresql_configure_logging
     is_boolean_yes "$create_conf_file" && postgresql_configure_connections


### PR DESCRIPTION
**Description of the change**

Ensure that postgresql_tls_auth_configuration is called when appropriate independent of whether the data directory is initialized

**Benefits**

Can use client certs for authentication without as much trouble

**Possible drawbacks**

Unaware of drawbacks

**Applicable issues**

https://github.com/bitnami/bitnami-docker-postgresql/issues/257

**Additional information**

First pull request for this project, hope I'm doing it right.
