### PR TITLE
libpostgresql: set wal_level to logical

### DIFF
--- a/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -367,7 +367,7 @@ postgresql_create_replication_user() {
 postgresql_configure_replication_parameters() {
     local -r psql_major_version="$(postgresql_get_major_version)"
     info "Configuring replication parameters"
-    postgresql_set_property "wal_level" "hot_standby"
+    postgresql_set_property "wal_level" "logical"
     postgresql_set_property "max_wal_size" "400MB"
     postgresql_set_property "max_wal_senders" "16"
     if ((psql_major_version >= 13)); then

--- a/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/11/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -367,7 +367,7 @@ postgresql_create_replication_user() {
 postgresql_configure_replication_parameters() {
     local -r psql_major_version="$(postgresql_get_major_version)"
     info "Configuring replication parameters"
-    postgresql_set_property "wal_level" "hot_standby"
+    postgresql_set_property "wal_level" "logical"
     postgresql_set_property "max_wal_size" "400MB"
     postgresql_set_property "max_wal_senders" "16"
     if ((psql_major_version >= 13)); then

--- a/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -367,7 +367,7 @@ postgresql_create_replication_user() {
 postgresql_configure_replication_parameters() {
     local -r psql_major_version="$(postgresql_get_major_version)"
     info "Configuring replication parameters"
-    postgresql_set_property "wal_level" "hot_standby"
+    postgresql_set_property "wal_level" "logical"
     postgresql_set_property "max_wal_size" "400MB"
     postgresql_set_property "max_wal_senders" "16"
     if ((psql_major_version >= 13)); then

--- a/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -367,7 +367,7 @@ postgresql_create_replication_user() {
 postgresql_configure_replication_parameters() {
     local -r psql_major_version="$(postgresql_get_major_version)"
     info "Configuring replication parameters"
-    postgresql_set_property "wal_level" "hot_standby"
+    postgresql_set_property "wal_level" "logical"
     postgresql_set_property "max_wal_size" "400MB"
     postgresql_set_property "max_wal_senders" "16"
     if ((psql_major_version >= 13)); then

--- a/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/9.6/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -367,7 +367,7 @@ postgresql_create_replication_user() {
 postgresql_configure_replication_parameters() {
     local -r psql_major_version="$(postgresql_get_major_version)"
     info "Configuring replication parameters"
-    postgresql_set_property "wal_level" "hot_standby"
+    postgresql_set_property "wal_level" "logical"
     postgresql_set_property "max_wal_size" "400MB"
     postgresql_set_property "max_wal_senders" "16"
     if ((psql_major_version >= 13)); then


### PR DESCRIPTION
Since Postgresql 9.6, the `hot_standby` value is deprecated and maps to
`replica`.

This changes it to `logical,` which includes all the information `replica`
provides - supporting applications which want that information level.

**Benefits**

Applications requiring `wal_level = logical` will work.

**Possible drawbacks**

Using a level of logical will increase the WAL volume, particularly if many tables are configured for REPLICA IDENTITY FULL and many UPDATE and DELETE statements are executed.

**Applicable issues**

Alternative to https://github.com/bitnami/bitnami-docker-postgresql/issues/292