### PR TITLE
Fix recovery.conf incorrect ownership

### DIFF
--- a/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/10/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -897,6 +897,7 @@ postgresql_configure_recovery() {
     else
         cp -f "$POSTGRESQL_BASE_DIR/share/recovery.conf.sample" "$POSTGRESQL_RECOVERY_FILE"
         chmod 600 "$POSTGRESQL_RECOVERY_FILE"
+        am_i_root && chown "$POSTGRESQL_DAEMON_USER:$POSTGRESQL_DAEMON_GROUP" "$POSTGRESQL_RECOVERY_FILE"
         postgresql_set_property "standby_mode" "on" "$POSTGRESQL_RECOVERY_FILE"
         postgresql_set_property "primary_conninfo" "host=${POSTGRESQL_MASTER_HOST} port=${POSTGRESQL_MASTER_PORT_NUMBER} user=${POSTGRESQL_REPLICATION_USER} password=${POSTGRESQL_REPLICATION_PASSWORD} application_name=${POSTGRESQL_CLUSTER_APP_NAME}" "$POSTGRESQL_RECOVERY_FILE"
         postgresql_set_property "trigger_file" "/tmp/postgresql.trigger.${POSTGRESQL_MASTER_PORT_NUMBER}" "$POSTGRESQL_RECOVERY_FILE"


### PR DESCRIPTION

**Description of the change**

Adds `chown` for `recovery.conf` file to `$POSTGRESQL_DAEMON_USER:$POSTGRESQL_DAEMON_GROUP` when running Postgresql 10 containers as `root`

**Benefits**

fixes issue #309 

**Possible drawbacks**

Unknown

**Applicable issues**

#309 
