### PR TITLE
allow preinit scripts to place signal files

### DIFF
--- a/14/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/14/debian-10/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -567,8 +567,6 @@ postgresql_clean_from_restart() {
 #########################
 postgresql_initialize() {
     info "Initializing PostgreSQL database..."
-    postgresql_clean_from_restart
-
     # This fixes an issue where the trap would kill the entrypoint.sh, if a PID was left over from a previous run
     # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
     rm -f "$POSTGRESQL_PID_FILE"

--- a/14/debian-10/rootfs/opt/bitnami/scripts/postgresql/setup.sh
+++ b/14/debian-10/rootfs/opt/bitnami/scripts/postgresql/setup.sh
@@ -25,6 +25,8 @@ trap "postgresql_stop" EXIT
 am_i_root && ensure_user_exists "$POSTGRESQL_DAEMON_USER" --group "$POSTGRESQL_DAEMON_GROUP"
 # Fix logging issue when running as root
 am_i_root && chmod o+w "$(readlink /dev/stdout)"
+# Remove flags and postmaster files from a previous run
+postgresql_clean_from_restart
 # Allow running custom pre-initialization scripts
 postgresql_custom_pre_init_scripts
 # Ensure PostgreSQL is initialized


### PR DESCRIPTION
we have a backup and recovery setup with wal-g.
through our own image extending this one we install wal-g and copy some scripts to start recovery etc.

one of the main things we need to do is touch `recovery.signal` in de postgresql data directory before booting postgres in order to finalize the recovery and pull the last wal files from archive.

unfortunately with the current setup it is impossible to create this file in the pre-init scripts since the file will be deleted right after in the initialize function.

the init scripts won't work either since postgres will be started in the background prior to these scripts running.

this PR makes it so that the signal files will be cleaned prior to the pre-init script execution, enabling the pre-init scripts to set signal files.